### PR TITLE
adds note about configuring fuel's data_path var

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ access to the [Labeled Faces in the Wild](http://vis-www.cs.umass.edu/lfw/) data
 pip install kerosene
 ```
 
-Kerosene depends on the [fuel](https://github.com/mila-udem/fuel) library, which will be installed automatically if needed.
+Kerosene depends on the [fuel](https://github.com/mila-udem/fuel) library, which will be installed automatically if needed. You will need to configure fuel's data path before you can use Kerosense. Please see fuel's [documenation](https://fuel.readthedocs.io/en/latest/built_in_datasets.html#environment-variable) for configuration options.
 
 Sometimes sudo is necessary for the pip command.
 


### PR DESCRIPTION
I had never used fuel before so I was a bit confused when I ran into an exception about a missing config file. This updates the README to help future users know where to look to configure fuel before using this library.