### PR TITLE
updates all examples, expect binarized_mnist, to work with latest keras

### DIFF
--- a/examples/binarized_mnist.py
+++ b/examples/binarized_mnist.py
@@ -9,6 +9,9 @@ from keras.layers.core import Dense, AutoEncoder
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
 from keras.layers import containers
+import keras.backend as K
+
+K.set_image_dim_ordering('th')
 
 '''
     Iain Murray's conversion of mnist to binary format. The
@@ -71,8 +74,8 @@ decoder = containers.Sequential([
     Dense(hidden_dim, activation=activation, input_shape=(final_dim,)),
     Dense(input_dim, activation=activation)])
 model.add(AutoEncoder(encoder=encoder, decoder=decoder, output_reconstruction=True))
-model.compile(loss='mean_squared_error', optimizer='adam')
-model.fit(X_train, X_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, X_test))
+model.compile(loss='mean_squared_error', optimizer='adam', metrics=['accuracy'])
+model.fit(X_train, X_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, X_test))
 
 # not sure if this is a valid way to evaluate the autoencoder...
 score = model.evaluate(X_test, X_test, show_accuracy=True, verbose=0)

--- a/examples/cifar10.py
+++ b/examples/cifar10.py
@@ -11,6 +11,9 @@ from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
 from keras.optimizers import SGD, Adadelta, Adagrad
+import keras.backend as K
+
+K.set_image_dim_ordering('th')
 
 '''
     Train a convnet on the CIFAR10 dataset.
@@ -75,9 +78,9 @@ model.add(Activation('softmax'))
 
 # let's train the model using SGD + momentum (how original).
 sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
-model.compile(loss='categorical_crossentropy', optimizer=sgd)
+model.compile(loss='categorical_crossentropy', optimizer=sgd, metrics=['accuracy'])
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Y_test))
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, Y_test))
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/cifar100.py
+++ b/examples/cifar100.py
@@ -11,6 +11,9 @@ from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
 from keras.optimizers import SGD, Adadelta, Adagrad
+import keras.backend as K
+
+K.set_image_dim_ordering('th')
 
 '''
     Train a convnet on the CIFAR100 dataset.
@@ -84,9 +87,9 @@ model.add(Activation('softmax'))
 
 # let's train the model using SGD + momentum (how original).
 sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
-model.compile(loss='categorical_crossentropy', optimizer=sgd)
+model.compile(loss='categorical_crossentropy', optimizer=sgd, metrics=['accuracy'])
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Y_test))
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, Y_test))
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])
@@ -97,7 +100,7 @@ print('Test accuracy:', score[1])
 Z_train = np_utils.to_categorical(z_train, nb_classes)
 Z_test = np_utils.to_categorical(z_test, nb_classes)
 
-model.fit(X_train, Z_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Z_test))
+model.fit(X_train, Z_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, Z_test))
 score = model.evaluate(X_test, Z_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/iris.py
+++ b/examples/iris.py
@@ -7,6 +7,9 @@ from kerosene.datasets import iris
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation
 from keras.utils import np_utils
+import keras.backend as K
+
+K.set_image_dim_ordering('th')
 
 '''
     Train something simple on the classic iris dataset.
@@ -34,6 +37,6 @@ Y_all = np_utils.to_categorical(y_all, nb_classes)
 model = Sequential()
 model.add(Dense(input_dim=input_dim, output_dim=nb_classes, init='glorot_uniform'))
 model.add(Activation('softmax'))
-model.compile(loss='mean_squared_error', optimizer='rmsprop')                    
+model.compile(loss='mean_squared_error', optimizer='rmsprop', metrics=['accuracy'])
 
-model.fit(X_all, Y_all, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, validation_split=0.25, verbose=1)
+model.fit(X_all, Y_all, batch_size=batch_size, nb_epoch=nb_epoch, validation_split=0.25, verbose=1)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -8,6 +8,9 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
+import keras.backend as K
+
+K.set_image_dim_ordering('th')
 
 '''
     Train a simple convnet on the MNIST dataset.
@@ -60,9 +63,10 @@ model.add(Dropout(0.5))
 model.add(Dense(nb_classes))
 model.add(Activation('softmax'))
 
-model.compile(loss='categorical_crossentropy', optimizer='adadelta')
+model.compile(loss='categorical_crossentropy', optimizer='adadelta', 
+              metrics=["accuracy"])
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Y_test))
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, Y_test))
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/svhn2.py
+++ b/examples/svhn2.py
@@ -11,6 +11,9 @@ from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
 from keras.optimizers import SGD, Adadelta, Adagrad
+import keras.backend as K
+
+K.set_image_dim_ordering('th')
 
 '''
     Train a convnet on the cropped Stanford Street View House Numbers dataset.
@@ -79,9 +82,9 @@ model.add(Activation('softmax'))
 
 # let's train the model using SGD + momentum (how original).
 sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
-model.compile(loss='categorical_crossentropy', optimizer=sgd)
+model.compile(loss='categorical_crossentropy', optimizer=sgd, metrics=['accuracy'])
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Y_test))
-score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, Y_test))
+score = model.evaluate(X_test, Y_test, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/kerosene/datasets/dataset.py
+++ b/kerosene/datasets/dataset.py
@@ -40,7 +40,7 @@ def fuel_data_to_list(fuel_data, shuffle):
     else:
         scheme = SequentialScheme(fuel_data.num_examples, fuel_data.num_examples)
     fuel_data_stream = DataStream.default_stream(fuel_data, iteration_scheme=scheme)
-    return fuel_data_stream.get_epoch_iterator().next()
+    return next(fuel_data_stream.get_epoch_iterator())
 
 def fuel_datasets_unpacked(fuel_datasets, shuffle=False):
     return map(lambda x: fuel_data_to_list(x, shuffle=shuffle), fuel_datasets)


### PR DESCRIPTION
I didn't update the `binarized_mnist` example since it was a bit more involved. The `AutoEncoder` layer was removed in place of the functional API so it should be easy to fix that was as well.  Note, that for all of the scripts I explicitly set the dimension order since TensorFlow and Theano have different defaults. Now these example scripts will also with the TensorFlow backend.

Also in this PR is a fix for Python 3.x compat that addresses issue #7.