### PR TITLE
Fixing next() iterator to work with Python 2 *or* Python 3

### DIFF
--- a/kerosene/datasets/dataset.py
+++ b/kerosene/datasets/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import os
+import os, sys
 import fuel
 from fuel.streams import DataStream
 from fuel.schemes import SequentialScheme, ShuffledScheme
@@ -40,7 +40,10 @@ def fuel_data_to_list(fuel_data, shuffle):
     else:
         scheme = SequentialScheme(fuel_data.num_examples, fuel_data.num_examples)
     fuel_data_stream = DataStream.default_stream(fuel_data, iteration_scheme=scheme)
-    return fuel_data_stream.get_epoch_iterator().next()
+    if(sys.version_info[0]<3):
+        return fuel_data_stream.get_epoch_iterator().next()
+    else:
+        return next(fuel_data_stream.get_epoch_iterator())
 
 def fuel_datasets_unpacked(fuel_datasets, shuffle=False):
     return map(lambda x: fuel_data_to_list(x, shuffle=shuffle), fuel_datasets)


### PR DESCRIPTION
Fuel is designed to work for Python 2 or 3. Kerosene mostly plays nice with Python 3, but when dealing with Fuel data streams, calling `obj.next()` instead of `obj.__next__()` causes Python 3 to choke (see [PEP 3114](https://www.python.org/dev/peps/pep-3114/)). This PR adds a check for the Python version. If 2, calls `obj.next()`, and if 3, calls `next(obj)` (which in turn calls `obj.__next__()`). 

(There is probably a more graceful way to do this but I'm not a 2-to-3-conversion master.)